### PR TITLE
Replace deprecated gulp-util with plugin-error

### DIFF
--- a/gulp-fn.js
+++ b/gulp-fn.js
@@ -1,13 +1,11 @@
 /*
 Gulp-Fn
  */
-var PLUGIN_NAME, PluginError, gulpFn, gutil, through;
+var PLUGIN_NAME, PluginError, gulpFn, through;
 
 through = require('through2');
 
-gutil = require('gulp-util');
-
-PluginError = gutil.PluginError;
+PluginError = require('plugin-error');
 
 PLUGIN_NAME = 'gulp-fn';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-fn",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "gulp-fn - gulp plugin used in order to run a custom function",
   "main": "gulp-fn.js",
   "repository": {
@@ -25,6 +25,6 @@
   "dependencies": {
     "gulp": "^3.6.2",
     "through2": "^0.4.2",
-    "gulp-util": "^2.2.14"
+    "plugin-error": "^1.0.1"
   }
 }


### PR DESCRIPTION
gulp-util is deprecated so I have replaced instances of it using the plugin-error replacement plugin.

gutil.PluginError => https://www.npmjs.com/package/plugin-error